### PR TITLE
Fix "lift" and "scope" types

### DIFF
--- a/packages/fui-core/src/main/fui-core.d.ts
+++ b/packages/fui-core/src/main/fui-core.d.ts
@@ -1,4 +1,4 @@
-declare function FuiCore<Type, Names extends PropertyKey, Methods = {}>(builder: FuiCore.FuiBuilder<Type, Names>, methods?: (tap: FuiCore.FuiTap<Type, Env, Methods>) => Methods): FuiCore.FuiEngine<Type, Names, Methods>;
+declare function FuiCore<Type, Names extends PropertyKey, Methods = {}>(builder: FuiCore.FuiBuilder<Type, Names>, methods?: (tap: FuiCore.FuiTap<Type, Methods>) => Methods): FuiCore.FuiEngine<Type, Names, Methods>;
 
 declare namespace FuiCore {
   type FuiEngine<Type, Names extends PropertyKey, Methods = {}> = Record<Names, FuiElement<Type, any, Methods> & Methods>;
@@ -8,14 +8,14 @@ declare namespace FuiCore {
     append(a: Type, b: Type): void
   }
 
-  type FuiTap<Type, Env, Methods> = (tap: (value: any, target: Type) => any) => FuiElement<Type, Env, Methods> & Methods;
+  type FuiTap<Type, Methods> = (tap: (value: any, target: Type) => any) => FuiElement<Type, unknown, Methods> & Methods;
 
   interface FuiElement<Type, Env, Methods> {
     (scope?: Env): Type;
 
     add: (element: this) => FuiElement<Type, Env, Methods> & Methods;
-    lift: <AltEnv = Env>(fn: (scope: AltEnv) => FuiElement<Type, AltEnv, Methods> & Methods) => FuiElement<Type, AltEnv, Methods> & Methods;
-    scope: <NewEnv>(fn: (scope: Env) => NewEnv) => FuiElement<Type, Env, Methods> & Methods;
+    lift: <AltEnv>(fn: (scope: AltEnv) => FuiElement<Type, AltEnv, Methods> & Methods) => FuiElement<Type, Env extends unknown ? AltEnv : Env, Methods> & Methods;
+    scope: <OldEnv>(fn: (scope: OldEnv) => Env) => FuiElement<Type, OldEnv, Methods> & Methods;
   }
 }
 

--- a/packages/fui-core/src/test/fui-core.spec.ts
+++ b/packages/fui-core/src/test/fui-core.spec.ts
@@ -7,7 +7,7 @@ interface FuiTestTarget {
 }
 
 interface FuiTestMethods {
-  data(str: string): this;
+  data(val: string | string[]): this;
 }
 
 const { foo, bar, baz } = core<FuiTestTarget, "foo" | "bar" | "baz", FuiTestMethods>({
@@ -17,9 +17,9 @@ const { foo, bar, baz } = core<FuiTestTarget, "foo" | "bar" | "baz", FuiTestMeth
   append(a: FuiTestTarget, b: FuiTestTarget) {
     return a.children.push(b)
   }
-}, (tap: core.FuiTap<FuiTestTarget, string, FuiTestMethods>) => ({
-  data(str: string | string[]) {
-    return tap((_, fx) => fx.data = str);
+}, (tap: core.FuiTap<FuiTestTarget, FuiTestMethods>) => ({
+  data(val: string | string[]) {
+    return tap((_, fx) => fx.data = val);
   }
 }));
 
@@ -48,7 +48,7 @@ const checks = [
     }]
   }],
 
-  [foo.lift<string>((data) => bar.data(data))("data"), {
+  [foo.lift((data: string) => bar.data(data))("data"), {
     name: "foo",
     children: [{
       name: "bar",
@@ -57,7 +57,7 @@ const checks = [
     }]
   }],
 
-  [foo.lift<string>((data) => bar.data(data).lift<string>((data) => baz.data(data)))("data"), {
+  [foo.lift((data: string) => bar.data(data).lift((data: string) => baz.data(data)))("data"), {
     name: "foo",
     children: [{
       name: "bar",
@@ -70,7 +70,7 @@ const checks = [
     }]
   }],
 
-  [foo.lift((data) => bar.data(data)).scope<string[]>((scope) => [scope, scope])("data"), {
+  [foo.lift((data: string[]) => bar.data(data).lift((data: string) => baz.data(data)).scope(([scope]: string[]) => scope))(["data", "data"]), {
     name: "foo",
     children: [{
       name: "bar",
@@ -78,11 +78,15 @@ const checks = [
         "data",
         "data",
       ],
-      children: []
+      children: [{
+        name: "baz",
+        data: "data",
+        children: []
+      }]
     }]
   }],
 
-  [foo.lift((data: string) => bar.data(data).lift((data: string) => baz.data(data)).scope((scope: string) => [scope, scope]))("data"), {
+  [foo.lift((data: string) => bar.data(data).lift((data: string[]) => baz.data(data)).scope((scope: string) => [scope, scope]))("data"), {
     name: "foo",
     children: [{
       name: "bar",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
       "es2018"
     ],
     "declaration": true,
+    "noImplicitAny": true,
     "skipLibCheck": true,
     "paths": {
       "@chaff/fui-core": [


### PR DESCRIPTION
Corrected the environment types for the lift and scope methods, and
updated the tests accordingly.

See: #15 